### PR TITLE
Add matrix to dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os:   [ 'ubuntu', 'macos' ]
-        ruby: [ '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1' ]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/networkx.gemspec
+++ b/networkx.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
   # spec.add_runtime_dependency 'nmatrix'
+  spec.add_runtime_dependency 'matrix'
   spec.add_runtime_dependency 'rb_heap'
 
   # spec.add_development_dependency 'guard-rspec' if RUBY_VERSION >= '2.2.5'


### PR DESCRIPTION
For compatibility with Ruby3.1

Matrix has been changed from the default gem to a bundled gem in Ruby 3.1, so we need to add it to runtime dependencies.
https://bugs.ruby-lang.org/issues/17873