### PR TITLE
feat: Add `dfs_edges` & `each_dfs_edge`

### DIFF
--- a/lib/networkx/graph.rb
+++ b/lib/networkx/graph.rb
@@ -447,6 +447,31 @@ module NetworkX
       end
     end
 
+    def dfs_edges(node)
+      each_dfs_edge(node).to_a
+    end
+
+    def each_dfs_edge(node)
+      return enum_for(:each_dfs_edge, node) unless block_given?
+
+      st = [node]
+      used = Array.new(number_of_nodes, false)
+      parents = Array.new(number_of_nodes)
+      while st[-1]
+        node = st.pop
+
+        yield(parents[node], node) if parents[node]
+
+        used[node] = true
+        @adj[node].reverse_each do |v, _data|
+          next if used[v]
+
+          parents[v] = node
+          st << v unless used[v]
+        end
+      end
+    end
+
     def multigraph?
       ['NetworkX::MultiGraph', 'NetworkX::MultiDiGraph'].include?(self.class.name)
     end

--- a/spec/network_x/graph_spec.rb
+++ b/spec/network_x/graph_spec.rb
@@ -207,4 +207,34 @@ RSpec.describe NetworkX::Graph do
     g.add_edges_from(edges)
     expect(g.dfs_nodes(1)).to eq(dfs_nodes)
   end
+
+  it 'test dfs_edges' do
+    edges = [[1, 2], [1, 3], [2, 4], [2, 5], [3, 6], [3, 7]]
+    dfs_edges = [[1, 2], [2, 4], [2, 5], [1, 3], [3, 6], [3, 7]]
+
+    g = NetworkX::Graph.new
+    g.add_nodes_from(1..7)
+    g.add_edges_from(edges)
+    expect(g.dfs_edges(1)).to eq(dfs_edges)
+  end
+
+  it 'test dfs_edges to line graph (ABC133 E sample1)' do
+    n, _k = 4, 3
+    edges = [[1, 2], [2, 3], [3, 4]]
+
+    g = NetworkX::Graph.new
+    g.add_nodes_from(1..n)
+    g.add_edges_from(edges)
+    expect(g.dfs_edges(1)).to eq([[1, 2], [2, 3], [3, 4]])
+  end
+
+  it 'test dfs_edges to line graph (ABC133 E sample2)' do
+    n, _k = 5, 4
+    edges = [[1, 2], [1, 3], [1, 4], [4, 5]]
+
+    g = NetworkX::Graph.new
+    g.add_nodes_from(1..n)
+    g.add_edges_from(edges)
+    expect(g.dfs_edges(1)).to eq([[1, 2], [1, 3], [1, 4], [4, 5]])
+  end
 end


### PR DESCRIPTION

- comparison
  - New `each_dfs_edges()`: 492ms  https://atcoder.jp/contests/abc133/submissions/36391214
  - `NetworkX.edge_dfs()`:  TLE(over 2209ms) https://atcoder.jp/contests/abc133/submissions/36389210



- Type of change :
  - [x] New feature
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests